### PR TITLE
Skip prctl(PR_CAP_AMBIENT) if PR_CAP_AMBIENT isn't defined

### DIFF
--- a/bubblewrap.c
+++ b/bubblewrap.c
@@ -584,9 +584,15 @@ prctl_caps (uint32_t *caps, bool do_cap_bounding, bool do_set_ambient)
 
       if (keep && do_set_ambient)
         {
+#ifdef PR_CAP_AMBIENT
           int res = prctl (PR_CAP_AMBIENT, PR_CAP_AMBIENT_RAISE, cap, 0, 0);
           if (res == -1 && !(errno == EINVAL || errno == EPERM))
             die_with_error ("Adding ambient capability %ld", cap);
+#else
+          /* We ignore the EINVAL that results from not having PR_CAP_AMBIENT
+           * in the current kernel at runtime, so also ignore not having it
+           * in the current kernel headers at compile-time */
+#endif
         }
 
       if (!keep && do_cap_bounding)


### PR DESCRIPTION
This means we can compile on Debian 8 'jessie', currently the
"oldstable" distribution. It's consistent with what would happen
if we knew PR_CAP_AMBIENT at compile-time but the kernel didn't support
it at runtime.

Signed-off-by: Simon McVittie <smcv@collabora.com>